### PR TITLE
Fix the type definitions are not published correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,12 @@
   "main": "dist/index.js",
   "module": "dist/index.modern.js",
   "source": "src/index.js",
-  "types": "src/index.d.ts",
+  "types": "dist/index.d.ts",
   "engines": {
     "node": ">=10"
   },
   "scripts": {
-    "build": "microbundle-crl -f cjs,umd src/index.cjs.js && microbundle-crl -f es,modern src/index.js",
+    "build": "microbundle-crl -f cjs,umd src/index.cjs.js && microbundle-crl -f es,modern src/index.js && cp src/index.d.ts dist",
     "start": "microbundle-crl watch -f cjs,umd",
     "prepare": "run-s build",
     "test": "run-s test:unit test:lint test:build",


### PR DESCRIPTION
## Problem

The type definitions that introduced by #2 are **not included** when I try to use `@theplant/google-map-react@0.1.1`

## Reason

The [files](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#files) config is [`["dist"]`](https://github.com/theplant/google-map-react/blob/master/package.json#L64), so all the other enties won't be included when published as a dependence, involved the `src/index.d.ts`.

## Fixing

Move the `index.d.ts` to `dist/index.d.ts` when build and publish